### PR TITLE
Do something with return value of getrandom

### DIFF
--- a/src/crypto/random.c
+++ b/src/crypto/random.c
@@ -20,7 +20,10 @@
 #include <stdint.h>
 
 #if defined(HAVE_GETRANDOM)
+#include <errno.h>
+#include <string.h>
 #include <sys/random.h>
+#include "neatvnc.h"
 #elif defined(HAVE_ARC4RANDOM)
 #include <stdlib.h>
 #endif
@@ -29,7 +32,17 @@
 void crypto_random(uint8_t* dst, size_t len)
 {
 #if defined(HAVE_GETRANDOM)
-	getrandom(dst, len, 0);
+	while (len) {
+		ssize_t nr = getrandom(dst, len, 0);
+		if (nr < 0) {
+			if (errno != EINTR && errno != EAGAIN)
+				nvnc_log(NVNC_LOG_PANIC, "getrandom failed: %s",
+					strerror(errno));
+			continue;
+		}
+		dst += nr;
+		len -= nr;
+	}
 #elif defined(HAVE_ARC4RANDOM)
 	arc4random_buf(dst, len);
 #else


### PR DESCRIPTION
`getrandom` [may be declared](https://sourceware.org/git/?p=glibc.git;a=blob;f=stdlib/sys/random.h;h=e4be2df02101a3d66ce82ac70561be8279fbca1c;hb=d2097651cc57834dbfcaa102ddfacae0d86cfb66#l34) with `warn_unused_result` (`__wur`). [Documentation says](https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man/man2/getrandom.2?h=man-pages-6.15#n269):

> The user of `getrandom ()` must always check the return value, to determine whether either an error occurred or fewer bytes than requested were returned.

I can't think of a realistic scenario where this matters, but you never know.

API is unchanged. The logic is:

* Continue reading on short reads.
* Retry on known temporary errors.
* Panic on other errors.
* Return only when the buffer is fully filled.